### PR TITLE
Use Offcenter.ts and keep MapScreen UseEffect closer to original

### DIFF
--- a/app/routes/_map.post.$id.($coordinates)._index/route.tsx
+++ b/app/routes/_map.post.$id.($coordinates)._index/route.tsx
@@ -1,5 +1,6 @@
 import { Companies, db, Posts } from "~/services.server/store";
 import type { Route } from "./+types/route";
+import { useOutletContext } from "react-router";
 
 export const loader = async ({
   request,
@@ -19,8 +20,12 @@ export default function PostPage({
   loaderData: { post, company },
   params,
 }: Route.ComponentProps) {
+  const { infoSectionRef } = useOutletContext<{
+    infoSectionRef: React.RefObject<HTMLDivElement>;
+  }>();
   return (
     <section
+      ref={infoSectionRef}
       className="z-50 flex max-h-[60%] flex-col rounded-t-2xl bg-white md:m-4 md:max-h-none md:w-[50%] md:max-w-prose md:min-w-[300px] md:rounded-2xl"
       style={{
         boxShadow: "0 0 2px rgb(0 0 0/20%),0 -1px 0 rgb(0 0 0/2%)",

--- a/app/routes/_map/route.tsx
+++ b/app/routes/_map/route.tsx
@@ -270,7 +270,7 @@ export default function MapScreen() {
   const infoSectionRef = React.useRef<HTMLDivElement>(null);
 
   const [sidebarWidth, setSidebarWidth] = React.useState(0);
-  
+  // observer for sidebar width
   React.useEffect(() => {
     const el = infoSectionRef.current;
     if (!el) return;
@@ -288,7 +288,7 @@ export default function MapScreen() {
     return () => observer.disconnect();
   }, []);
 
-
+  // This effect is used to update the map view when the selected location or post changes
   React.useEffect(() => {
     const map = map_ref.current!;
     if (!map) {
@@ -343,7 +343,7 @@ export default function MapScreen() {
             await new Promise((r) => setTimeout(r, 300));
             again.spiderfy();
           }
-        })();
+        });
       } else {
         if (!bounds.contains(coords)) {
           map.setView(

--- a/app/routes/_map/route.tsx
+++ b/app/routes/_map/route.tsx
@@ -268,10 +268,7 @@ export default function MapScreen() {
   const open_pcs = open_pcs_1 ?? open_pcs_2 ?? open_pcs_3 ?? ({} as any);
 
   const infoSectionRef = React.useRef<HTMLDivElement>(null);
-  const didInitialRecenter = React.useRef(false);
 
-
-  const [sidebarReady, setSidebarReady] = React.useState(false);
   const [sidebarWidth, setSidebarWidth] = React.useState(0);
   
   React.useEffect(() => {
@@ -282,8 +279,6 @@ export default function MapScreen() {
       const width = el.getBoundingClientRect().width;
       if (width > 0) {
         setSidebarWidth(width);
-        setSidebarReady(true);
-        console.log("✅ Sidebar measured:", width);
       }
     };
   
@@ -297,7 +292,6 @@ export default function MapScreen() {
   React.useEffect(() => {
     const map = map_ref.current!;
     if (!map) {
-      console.warn("⛔ map_ref.current is null, skipping recenter");
       return;
     }
   

--- a/app/routes/_map/route.tsx
+++ b/app/routes/_map/route.tsx
@@ -267,98 +267,120 @@ export default function MapScreen() {
   const open_pcs_3 = useMatch("/post/:post/*")?.params;
   const open_pcs = open_pcs_1 ?? open_pcs_2 ?? open_pcs_3 ?? ({} as any);
 
+  const infoSectionRef = React.useRef<HTMLDivElement>(null);
+
+  const [sidebarWidth, setSidebarWidth] = React.useState(0);
+
+  React.useEffect(() => {
+    const el = infoSectionRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      const width = el.getBoundingClientRect().width;
+      if (width > 0) {
+        console.log("✅ Sidebar measured:", width);
+        setSidebarWidth(width);
+      }
+    };
+
+    measure(); // measure immediately
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+
   React.useEffect(() => {
     const map = map_ref.current!;
-
+    if (!map) {
+      console.warn("⛔ map_ref.current is null, skipping fitBounds");
+      return;
+    }
+    const safearea_offsets = safearea.get();
+  
     const refs =
-      "location" in open_pcs ?
-        {
-          cluster_group: pcs_cluster_ref.current,
-          marker: pcs_marker_refs.current[open_pcs.location!],
-        }
-      : null;
-
+      "location" in open_pcs
+        ? {
+            cluster_group: pcs_cluster_ref.current,
+            marker: pcs_marker_refs.current[open_pcs.location!],
+          }
+        : null;
+  
     if (refs && map && refs.marker) {
       const { cluster_group, marker } = refs;
-
+  
       const coordinates = marker.getLatLng();
       const to = [coordinates.lat, coordinates.lng] as [number, number];
-
-      const safearea_offsets = safearea.get();
-      // let skillbridge = dod_locations.find((x) => x.id === open_location_id)!;
-      // let cluster_group = markers_ref.current;
-      // let marker = marker_refs.current[open_location_id];
-
+  
       const bounds = Offcenter.getBounds(map, safearea_offsets);
-
       const cluster = cluster_group?.getVisibleParent(marker);
-      if (cluster != marker) {
-        // map.setView([skillbridge.location.LAT, skillbridge.location.LONG], 12);
-        // if (bounds.contains(to)) return;
-        // dod_cluster_ref.current.zoomToShowLayer(layer)
-
+  
+      if (cluster !== marker) {
         async(async () => {
           const new_zoom = Math.max(12, map.getZoom());
           if (!bounds.contains(to) || new_zoom !== map.getZoom()) {
-            // @ts-ignore
-            const uhhh = marker.__parent as MarkerCluster;
-            // @ts-ignore
-            const zoomies = uhhh._zoom as number;
-            const new_zoom =
-              (
-                (map.getZoom() >= 7 && uhhh.getChildCount() < 5) ||
-                map.getZoom() >= 9
-              ) ?
-                map.getZoom()
-              : clamp(
-                  zoomies + 1,
-                  Math.max(map.getZoom(), 8),
-                  map.getMaxZoom(),
-                );
-
+            const parent = marker.__parent as MarkerCluster;
+            const zoomies = parent._zoom;
+            const adjustedZoom =
+              (map.getZoom() >= 7 && parent.getChildCount() < 5) ||
+              map.getZoom() >= 9
+                ? map.getZoom()
+                : clamp(
+                    zoomies + 1,
+                    Math.max(map.getZoom(), 8),
+                    map.getMaxZoom()
+                  );
+  
             map.setView(
-              Offcenter.recenter(to, new_zoom, safearea_offsets),
-              new_zoom,
-              {
-                animate: true,
-              },
+              Offcenter.recenter(to, adjustedZoom, safearea_offsets),
+              adjustedZoom,
+              { animate: true }
             );
-
+  
             await Promise.race([
-              new Promise((resolve) => {
-                map.once("moveend zoomend", () => resolve(undefined));
-              }),
-              new Promise((resolve) => {
-                setTimeout(resolve, 500);
-              }),
+              new Promise((resolve) =>
+                map.once("moveend zoomend", () => resolve(undefined))
+              ),
+              new Promise((resolve) => setTimeout(resolve, 500)),
             ]);
           }
-
-          const cluster = cluster_group?.getVisibleParent(marker);
-          if (cluster instanceof MarkerCluster) {
-            const c = cluster as MarkerCluster;
-            await new Promise((resolve) => {
-              setTimeout(resolve, 300);
-            });
-            c.spiderfy();
-          } else {
-            /// pass
+  
+          const clusterAgain = cluster_group?.getVisibleParent(marker);
+          if (clusterAgain instanceof MarkerCluster) {
+            await new Promise((resolve) => setTimeout(resolve, 300));
+            clusterAgain.spiderfy();
           }
         });
       } else {
         if (bounds.contains(coordinates)) return;
-
+  
         map.setView(
           Offcenter.recenter(to, map.getZoom(), safearea_offsets),
           map.getZoom(),
-          { animate: true, duration: 0.7 },
+          { animate: true, duration: 0.7 }
         );
+      }
+    }
+  
+    if ("post" in open_pcs) {
+      const selectedPost = pcs_posts.find((post) => post.id === open_pcs.post);
+      if (selectedPost && selectedPost.locations.length > 0) {
+        const bounds = new LatLngBounds(
+          selectedPost.locations.map((location) => [
+            location.data.coordinates.lat,
+            location.data.coordinates.lng,
+          ])
+        );
+  
+        Offcenter.fitBounds(map, bounds, safearea_offsets, sidebarWidth);
       }
     }
   }, [
     "location" in open_pcs && open_pcs.location,
     "post" in open_pcs && open_pcs.post,
   ]);
+  
 
   const selected_location = React.useMemo<MapState["selected_location"]>(() => {
     if ("location" in open_pcs) {
@@ -567,7 +589,7 @@ export default function MapScreen() {
 
           <div className="pointer-events-none absolute inset-0 flex flex-col-reverse justify-start overflow-hidden md:flex-row">
             <div className="pointer-events-auto contents">
-              <Outlet />
+              <Outlet context={{ infoSectionRef }} />
             </div>
             <div
               className="absolute inset-0 m-4 md:static md:inset-auto md:flex-1"

--- a/app/shared/leaflet/offcenter.ts
+++ b/app/shared/leaflet/offcenter.ts
@@ -127,36 +127,4 @@ export const Offcenter = {
       zoom,
     );
   },
-  
-  fitBounds: (
-    map: Map,
-    bounds: LatLngBounds,
-    offsets: SafeareaOffsets,
-    extraLeftPadding: number = 0,
-    padding: number = 80,
-  ) => {
-    map.fitBounds(bounds, {
-      paddingTopLeft: [offsets.left + extraLeftPadding, padding],
-      paddingBottomRight: [padding, padding],
-      animate: true,
-    });
-  },
-  
-  fitBoundsIfNeeded: (
-      map: Map,
-      targetBounds: LatLngBounds,
-      offsets: SafeareaOffsets,
-      extraLeftPadding = 0,
-      padding = 80,
-    ) => {
-      const current = Offcenter.getBounds(map, offsets);
-      if (!current.contains(targetBounds)) {
-        map.fitBounds(targetBounds, {
-          paddingTopLeft: [offsets.left + extraLeftPadding, padding],
-          paddingBottomRight: [padding, padding],
-          animate: true,
-        });
-      }
-    }
-  
 };

--- a/app/shared/leaflet/offcenter.ts
+++ b/app/shared/leaflet/offcenter.ts
@@ -127,4 +127,39 @@ export const Offcenter = {
       zoom,
     );
   },
+  
+  fitBounds: (
+    map: Map,
+    bounds: LatLngBounds,
+    offsets: SafeareaOffsets,
+    extraLeftPadding: number = 0,
+    padding: number = 80,
+  ) => {
+    map.fitBounds(bounds, {
+      paddingTopLeft: [offsets.left + extraLeftPadding, padding],
+      paddingBottomRight: [padding, padding],
+      animate: true,
+    });
+  },
+  
+  fitBoundsIfNeeded: (
+    map: Map,
+    targetBounds: LatLngBounds,
+    offsets: SafeareaOffsets,
+    extraLeftPadding: number = 0,
+    padding: number = 80,
+  ) => {
+    const current = Offcenter.getBounds(map, offsets);
+  
+    if (!current.contains(targetBounds)) {
+      map.fitBounds(targetBounds, {
+        paddingTopLeft: [offsets.left + extraLeftPadding, padding],
+        paddingBottomRight: [padding, padding],
+        animate: true,
+      });
+    } else {
+      console.log("🛑 Skipped fitBounds — already in view.");
+    }
+  },
+  
 };

--- a/app/shared/leaflet/offcenter.ts
+++ b/app/shared/leaflet/offcenter.ts
@@ -143,23 +143,20 @@ export const Offcenter = {
   },
   
   fitBoundsIfNeeded: (
-    map: Map,
-    targetBounds: LatLngBounds,
-    offsets: SafeareaOffsets,
-    extraLeftPadding: number = 0,
-    padding: number = 80,
-  ) => {
-    const current = Offcenter.getBounds(map, offsets);
-  
-    if (!current.contains(targetBounds)) {
-      map.fitBounds(targetBounds, {
-        paddingTopLeft: [offsets.left + extraLeftPadding, padding],
-        paddingBottomRight: [padding, padding],
-        animate: true,
-      });
-    } else {
-      console.log("🛑 Skipped fitBounds — already in view.");
+      map: Map,
+      targetBounds: LatLngBounds,
+      offsets: SafeareaOffsets,
+      extraLeftPadding = 0,
+      padding = 80,
+    ) => {
+      const current = Offcenter.getBounds(map, offsets);
+      if (!current.contains(targetBounds)) {
+        map.fitBounds(targetBounds, {
+          paddingTopLeft: [offsets.left + extraLeftPadding, padding],
+          paddingBottomRight: [padding, padding],
+          animate: true,
+        });
+      }
     }
-  },
   
 };


### PR DESCRIPTION
I decided to try to use your offcenter.ts file and simplify more. In creating the fixBounds method there were some more map issues to fight with (namely when the page was reloaded centering and zooming were not working correctly). 

I wanted to try to make the changes even simpler and easier to read.